### PR TITLE
Configure GitHub Pages deployment and add static index

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Transporte Accesible Cali</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 20px;
+            color: #333;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+        }
+        .header {
+            background-color: #0275d8;
+            color: white;
+            padding: 10px 20px;
+            margin-bottom: 20px;
+            border-radius: 5px;
+        }
+        .nav {
+            margin-bottom: 20px;
+        }
+        .nav a {
+            display: inline-block;
+            padding: 8px 16px;
+            background-color: #0275d8;
+            color: white;
+            text-decoration: none;
+            margin-right: 5px;
+            border-radius: 5px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Transporte Accesible Cali</h1>
+            <p>Interfaz estática para GitHub Pages</p>
+        </div>
+        <div class="nav">
+            <a href="rutas.html">Rutas</a>
+            <a href="paradas.html">Paradas</a>
+            <a href="docs/index.html">Documentación</a>
+        </div>
+        <p>Esta es una versión estática de la aplicación pensada para ser publicada en GitHub Pages. Para la versión completa con funcionalidades dinámicas, ejecute el backend de Flask incluido en este repositorio.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add GitHub Pages workflow for automatic deployment from main
- Provide static index.html so Pages serves the app instead of README

## Testing
- ❌ `python -m pytest` (ImportError: cannot import name '_request_ctx_stack' from 'flask')

------
https://chatgpt.com/codex/tasks/task_b_68aa535f221c83269541250ad2bc9bf4